### PR TITLE
Add MT-2 style stereo distortion with 4x oversampling (V0.6)

### DIFF
--- a/src/distortion/Makefile
+++ b/src/distortion/Makefile
@@ -1,0 +1,15 @@
+# Project Name
+TARGET = distortion
+
+USE_DAISYSP_LGPL=1
+
+# Sources
+CPP_SOURCES = distortion.cpp distortion_engine.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../../lib/libDaisy
+DAISYSP_DIR = ../../lib/DaisySP
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/src/distortion/README.md
+++ b/src/distortion/README.md
@@ -1,0 +1,106 @@
+# Distortion V0.6
+
+## Current State
+
+Boss MT-2 (Metal Zone) inspired stereo distortion for the Loewenzahnhonig-module by WGD Modular,
+with 4x oversampling around the clipping stages. Perfectly fits your Acid-Distortion-Needs with an 303'ish synth.
+
+- DaisySeed and stereo audio initialized
+- ADC set up for four pots and two CV inputs
+- Two-stage distortion (soft -> hard) with pre-emphasis before and tone
+  shaping after
+- 4x oversampling of the nonlinearities via polyphase allpass halfband
+  filters
+- Separate filter states for left and right channel
+- Fixed (non-adjustable) noise gate that mutes the amplified idle noise
+  floor at high gain settings
+- Block-based, sample-rate-aware parameter smoothing
+- Safe output protection
+
+> The firmware is MT-2 inspired by, but not an exact digital reproduction of
+> the original pedal.
+
+## Architecture
+
+- `distortion.cpp`: hardware initialization, ADC, control updates and
+  audio callback
+- `distortion_engine.cpp/.h`: parameter state, smoothing, oversampler and
+  the complete stereo DSP signal path
+- The audio callback delegates one stereo block directly to the DSP engine.
+- All filters run without dynamic memory allocation.
+
+## Controls
+
+- Pot 1: Distortion
+- Pot 2: Low (shelving filter at 100 Hz, center = flat)
+- Pot 3: High (shelving filter at 3.2 kHz, center = flat)
+- Pot 4: Output Level
+- CV 1: Distortion modulation
+- CV 2: High modulation
+
+Following the hardware convention, CV1 and CV2 are read inverted, scaled by
+`0.5` and added to the corresponding pot value. The result is clamped to
+`0.0` to `1.0`.
+
+## Signal Path
+
+DC blocker -> tight highpass (75 Hz) -> pre-emphasis (mid boost 950 Hz,
+high shelf 2.2 kHz) -> distortion gain -> [4x upsampling -> soft clip
+(tanh) -> hard clip (cubic curve with hard limit) -> 4x downsampling] ->
+fixed mid scoop (700 Hz, -8 dB) -> fizz lowpass (7.5 kHz) -> low shelf ->
+high shelf -> output level -> noise gate -> output clamp
+
+The noise gate sidechain reads the DC-blocked *input*, so the gate decision
+is unaffected by gain and tone settings; the gate gain is applied to the
+*output*, like a gate placed after a distortion pedal.
+
+Processing stays fully stereo. There is no mono summing.
+
+## Sound Goal
+
+- classic MT-2 sound: scooped mids, dense compression, sawing presence
+- tight bass through the pre-distortion tight highpass, recoverable via
+  the Low control after distortion
+- controlled highs without digital fizz (fizz lowpass)
+- significantly reduced aliasing through 4x oversampling
+
+## Technical Details
+
+- DC blocker: sample-rate-aware one-pole highpass at 5 Hz
+- Tight highpass: one-pole highpass at 75 Hz before distortion
+- Pre-emphasis: peaking EQ +8 dB at 950 Hz (Q 0.70) and high shelf +4 dB
+  at 2.2 kHz -- shapes the MT-2 aggression before clipping
+- Distortion gain: `3.0 * powf(120.0, distortion)`, approx. 3x to 360x
+  (+9.5 dB to +51 dB)
+- Oversampling: 4x via two cascaded 2x polyphase allpass halfband stages
+  (2 allpass sections per path, ~70 dB stopband, numerically verified:
+  audible aliasing 15-20 dB lower than without oversampling, passband
+  ripple of the chain < 0.01 dB)
+- First clipping stage: symmetric soft clip using `tanhf()`
+- Second clipping stage: 1.6x gain, cubic saturation `1.5x - 0.5x^3` with
+  hard limit at `+/-1.0`
+- Mid scoop: fixed peaking EQ at 700 Hz, Q 0.80, -8 dB (MT-2 signature)
+- Fizz lowpass: one-pole lowpass at 7.5 kHz after distortion
+- Low: RBJ low shelf at 100 Hz, -12 dB to +12 dB, center flat
+- High: RBJ high shelf at 3.2 kHz, -12 dB to +8 dB, center flat
+- Output level: quadratic curve `level * level * 1.25`
+- Noise gate (fixed): opens at -54 dBFS input level, closes below -60 dBFS
+  (hysteresis); envelope attack 0.5 ms, release 25 ms; gate opens in ~2 ms,
+  holds 50 ms and fades out over ~80 ms per time constant (silence roughly
+  0.7 s after the signal stops); per channel, no controls
+- Smoothing: block-based with approx. 20 ms time constant, coefficient
+  derived from sample rate and block size
+- Filter coefficients: RBJ biquads; fixed filters are computed once in
+  `Init()`, variable filters only after relevant parameter changes
+- Output protection: hard limit to `-1.0` to `+1.0`; non-finite values are
+  discarded
+
+## Not Yet Included (Maybe to be continued)
+
+- exact analog MT-2 circuit emulation (incl. parametric mid control)
+- presets
+- switching between multiple models
+- auto gain
+
+Final sound tuning has to happen on the target hardware with synths, bass,
+drums, drones and noise.

--- a/src/distortion/distortion.cpp
+++ b/src/distortion/distortion.cpp
@@ -1,0 +1,74 @@
+#include "../../lib/loewy.h"
+#include "daisy_seed.h"
+#include "distortion_engine.h"
+
+using namespace daisy;
+using namespace loewy;
+
+/*
+ * Stereo distortion firmware for Loewenzahnhonig-Modul from WGD (Boss MT-2 inspired, 4x oversampled).
+ *
+ * Pot 1: Distortion
+ * Pot 2: Low (shelf cut/boost, center = flat)
+ * Pot 3: High (shelf cut/boost, center = flat)
+ * Pot 4: Output Level
+ * CV 1: Distortion modulation
+ * CV 2: High modulation
+ */
+
+DaisySeed hw;
+DistortionEngine distortion;
+
+const float cvAmount = 0.5f;
+
+float clamp(float n, float lower, float upper) {
+  return n <= lower ? lower : n >= upper ? upper : n;
+}
+
+void ReadControls() {
+  float distortionPot = hw.adc.GetFloat(Loewy::Pot::POT_1);
+  float lowColor = hw.adc.GetFloat(Loewy::Pot::POT_2);
+  float highColorPot = hw.adc.GetFloat(Loewy::Pot::POT_3);
+  float level = hw.adc.GetFloat(Loewy::Pot::POT_4);
+
+  float cv1 = 1.0f - hw.adc.GetFloat(Loewy::CV::CV_1);
+  float cv2 = 1.0f - hw.adc.GetFloat(Loewy::CV::CV_2);
+
+  float distortionAmount =
+      clamp(distortionPot + cv1 * cvAmount, 0.0f, 1.0f);
+  float highColor = clamp(highColorPot + cv2 * cvAmount, 0.0f, 1.0f);
+
+  distortion.SetParameters(distortionAmount, lowColor, highColor, level);
+}
+
+void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer out,
+                   size_t size) {
+  distortion.ProcessBlock(in[0], in[1], out[0], out[1], size);
+}
+
+int main(void) {
+  hw.Configure();
+  hw.Init();
+  hw.SetAudioBlockSize(4);
+
+  float sampleRate = hw.AudioSampleRate();
+  distortion.Init(sampleRate);
+
+  AdcChannelConfig adcConfig[6];
+  adcConfig[0].InitSingle(hw.GetPin(15));
+  adcConfig[1].InitSingle(hw.GetPin(16));
+  adcConfig[2].InitSingle(hw.GetPin(17));
+  adcConfig[3].InitSingle(hw.GetPin(18));
+  adcConfig[4].InitSingle(hw.GetPin(19));
+  adcConfig[5].InitSingle(hw.GetPin(20));
+  hw.adc.Init(adcConfig, 6);
+  hw.adc.Start();
+
+  ReadControls();
+  hw.StartAudio(AudioCallback);
+
+  while (1) {
+    ReadControls();
+    System::Delay(1);
+  }
+}

--- a/src/distortion/distortion_engine.cpp
+++ b/src/distortion/distortion_engine.cpp
@@ -1,0 +1,483 @@
+#include "distortion_engine.h"
+
+#include <float.h>
+#include <math.h>
+
+namespace {
+
+const float kPi = 3.14159265358979323846f;
+const float kDefaultSampleRate = 48000.0f;
+const float kSmoothingTimeSeconds = 0.02f;
+const float kParameterUpdateThreshold = 0.0005f;
+
+const float kDcBlockerFrequency = 5.0f;
+const float kTightHighpassFrequency = 75.0f;
+const float kFizzLowpassFrequency = 7500.0f;
+
+const float kMinimumDistortionGain = 3.0f;
+const float kDistortionGainRange = 120.0f;
+const float kSecondClipGain = 1.6f;
+
+const float kPreMidBoostFrequency = 950.0f;
+const float kPreMidBoostQ = 0.70f;
+const float kPreMidBoostGainDb = 8.0f;
+const float kPreHighShelfFrequency = 2200.0f;
+const float kPreHighShelfQ = 0.707f;
+const float kPreHighShelfGainDb = 4.0f;
+
+const float kMidScoopFrequency = 700.0f;
+const float kMidScoopQ = 0.80f;
+const float kMidScoopGainDb = -8.0f;
+
+const float kLowShelfFrequency = 100.0f;
+const float kLowShelfQ = 0.707f;
+const float kLowShelfCutDb = 12.0f;
+const float kLowShelfBoostDb = 12.0f;
+const float kHighShelfFrequency = 3200.0f;
+const float kHighShelfQ = 0.707f;
+const float kHighShelfCutDb = 12.0f;
+const float kHighShelfBoostDb = 8.0f;
+
+const float kOutputMakeupGain = 1.25f;
+
+// Fixed noise gate: sidechain reads the DC-blocked input, the gain is
+// applied to the output. Thresholds sit far below any real eurorack
+// signal but above the amplified codec noise floor.
+const float kGateOpenThreshold = 0.002f;   // ~ -54 dBFS
+const float kGateCloseThreshold = 0.001f;  // ~ -60 dBFS
+const float kGateEnvelopeAttackSeconds = 0.0005f;
+const float kGateEnvelopeReleaseSeconds = 0.025f;
+const float kGateOpenSeconds = 0.002f;
+const float kGateCloseSeconds = 0.08f;
+const float kGateHoldSeconds = 0.05f;
+
+// Polyphase allpass halfband pair (hiir-style, ~70 dB stopband above
+// 0.6 * Nyquist, flat passband). [path][section]
+const float kHalfbandCoefficients[2][2] = {
+    {0.07986642623635751f, 0.5453536510711322f},
+    {0.28382934487410993f, 0.8344118914807379f},
+};
+
+}  // namespace
+
+void DistortionEngine::Init(float sampleRate) {
+  sampleRate_ = sampleRate > 1.0f ? sampleRate : kDefaultSampleRate;
+  smoothingBlockSize_ = 0;
+  smoothingCoefficient_ = 1.0f;
+
+  distortionTarget_ = 0.0f;
+  distortionCurrent_ = 0.0f;
+  lowTarget_ = 0.5f;
+  lowCurrent_ = 0.5f;
+  highTarget_ = 0.5f;
+  highCurrent_ = 0.5f;
+  levelTarget_ = 0.0f;
+  levelCurrent_ = 0.0f;
+
+  distortionGain_ = kMinimumDistortionGain;
+  distortionGainValue_ = -1.0f;
+  lowValue_ = -1.0f;
+  highValue_ = -1.0f;
+  levelGain_ = 0.0f;
+
+  dcBlockerCoefficient_ =
+      expf(-2.0f * kPi * kDcBlockerFrequency / sampleRate_);
+  tightHighpassCoefficient_ =
+      expf(-2.0f * kPi * kTightHighpassFrequency / sampleRate_);
+  fizzLowpassCoefficient_ =
+      1.0f - expf(-2.0f * kPi * kFizzLowpassFrequency / sampleRate_);
+
+  gateEnvelopeAttackCoefficient_ =
+      1.0f - expf(-1.0f / (kGateEnvelopeAttackSeconds * sampleRate_));
+  gateEnvelopeReleaseCoefficient_ =
+      1.0f - expf(-1.0f / (kGateEnvelopeReleaseSeconds * sampleRate_));
+  gateOpenCoefficient_ = 1.0f - expf(-1.0f / (kGateOpenSeconds * sampleRate_));
+  gateCloseCoefficient_ =
+      1.0f - expf(-1.0f / (kGateCloseSeconds * sampleRate_));
+  gateHoldSamples_ = static_cast<int>(kGateHoldSeconds * sampleRate_);
+
+  for (int channel = 0; channel < kNumChannels; channel++) {
+    dcInputState_[channel] = 0.0f;
+    dcOutputState_[channel] = 0.0f;
+    tightInputState_[channel] = 0.0f;
+    tightOutputState_[channel] = 0.0f;
+    fizzState_[channel] = 0.0f;
+    gateEnvelope_[channel] = 0.0f;
+    gateGain_[channel] = 0.0f;
+    gateHoldCounter_[channel] = 0;
+    gateOpen_[channel] = false;
+  }
+
+  ResetBiquad(&preMidBoostFilter_);
+  ResetBiquad(&preHighShelfFilter_);
+  ResetBiquad(&midScoopFilter_);
+  ResetBiquad(&lowShelfFilter_);
+  ResetBiquad(&highShelfFilter_);
+
+  ResetHalfband(&upsampleStage1_);
+  ResetHalfband(&upsampleStage2_);
+  ResetHalfband(&downsampleStage1_);
+  ResetHalfband(&downsampleStage2_);
+
+  ConfigurePeaking(&preMidBoostFilter_, kPreMidBoostFrequency, kPreMidBoostQ,
+                   kPreMidBoostGainDb);
+  ConfigureHighShelf(&preHighShelfFilter_, kPreHighShelfFrequency,
+                     kPreHighShelfQ, kPreHighShelfGainDb);
+  ConfigurePeaking(&midScoopFilter_, kMidScoopFrequency, kMidScoopQ,
+                   kMidScoopGainDb);
+
+  UpdateDerivedParameters();
+}
+
+void DistortionEngine::SetParameters(float distortion, float lowColor,
+                                     float highColor, float level) {
+  distortionTarget_ = Clamp(distortion, 0.0f, 1.0f);
+  lowTarget_ = Clamp(lowColor, 0.0f, 1.0f);
+  highTarget_ = Clamp(highColor, 0.0f, 1.0f);
+  levelTarget_ = Clamp(level, 0.0f, 1.0f);
+}
+
+void DistortionEngine::ProcessBlock(const float* inputLeft,
+                                    const float* inputRight, float* outputLeft,
+                                    float* outputRight, size_t size) {
+  UpdateSmoothingCoefficient(size);
+  SmoothParameters();
+  UpdateDerivedParameters();
+
+  for (size_t i = 0; i < size; i++) {
+    outputLeft[i] = ProcessSample(inputLeft[i], 0);
+    outputRight[i] = ProcessSample(inputRight[i], 1);
+  }
+}
+
+float DistortionEngine::Clamp(float value, float lower, float upper) {
+  return value <= lower ? lower : value >= upper ? upper : value;
+}
+
+void DistortionEngine::UpdateSmoothingCoefficient(size_t blockSize) {
+  if (blockSize == smoothingBlockSize_) {
+    return;
+  }
+
+  smoothingBlockSize_ = blockSize;
+  smoothingCoefficient_ =
+      1.0f - expf(-static_cast<float>(blockSize) /
+                  (kSmoothingTimeSeconds * sampleRate_));
+}
+
+void DistortionEngine::SmoothParameters() {
+  distortionCurrent_ +=
+      smoothingCoefficient_ * (distortionTarget_ - distortionCurrent_);
+  lowCurrent_ += smoothingCoefficient_ * (lowTarget_ - lowCurrent_);
+  highCurrent_ += smoothingCoefficient_ * (highTarget_ - highCurrent_);
+  levelCurrent_ += smoothingCoefficient_ * (levelTarget_ - levelCurrent_);
+}
+
+void DistortionEngine::UpdateDerivedParameters() {
+  if (fabsf(distortionCurrent_ - distortionGainValue_) >=
+      kParameterUpdateThreshold) {
+    distortionGainValue_ = distortionCurrent_;
+    distortionGain_ = kMinimumDistortionGain *
+                      powf(kDistortionGainRange, distortionCurrent_);
+  }
+
+  if (fabsf(lowCurrent_ - lowValue_) >= kParameterUpdateThreshold) {
+    lowValue_ = lowCurrent_;
+    float gainDb = MapShelfGain(lowCurrent_, kLowShelfCutDb, kLowShelfBoostDb);
+    ConfigureLowShelf(&lowShelfFilter_, kLowShelfFrequency, kLowShelfQ,
+                      gainDb);
+  }
+
+  if (fabsf(highCurrent_ - highValue_) >= kParameterUpdateThreshold) {
+    highValue_ = highCurrent_;
+    float gainDb =
+        MapShelfGain(highCurrent_, kHighShelfCutDb, kHighShelfBoostDb);
+    ConfigureHighShelf(&highShelfFilter_, kHighShelfFrequency, kHighShelfQ,
+                       gainDb);
+  }
+
+  levelGain_ = levelCurrent_ * levelCurrent_ * kOutputMakeupGain;
+}
+
+void DistortionEngine::ResetBiquad(Biquad* filter) {
+  filter->b0 = 1.0f;
+  filter->b1 = 0.0f;
+  filter->b2 = 0.0f;
+  filter->a1 = 0.0f;
+  filter->a2 = 0.0f;
+
+  for (int channel = 0; channel < kNumChannels; channel++) {
+    filter->z1[channel] = 0.0f;
+    filter->z2[channel] = 0.0f;
+  }
+}
+
+void DistortionEngine::ConfigurePeaking(Biquad* filter, float frequency,
+                                        float q, float gainDb) {
+  float safeFrequency = Clamp(frequency, 10.0f, sampleRate_ * 0.45f);
+  float safeQ = q < 0.1f ? 0.1f : q;
+  float amplitude = powf(10.0f, gainDb / 40.0f);
+  float omega = 2.0f * kPi * safeFrequency / sampleRate_;
+  float alpha = sinf(omega) / (2.0f * safeQ);
+  float cosine = cosf(omega);
+
+  float b0 = 1.0f + alpha * amplitude;
+  float b1 = -2.0f * cosine;
+  float b2 = 1.0f - alpha * amplitude;
+  float a0 = 1.0f + alpha / amplitude;
+  float a1 = -2.0f * cosine;
+  float a2 = 1.0f - alpha / amplitude;
+
+  filter->b0 = b0 / a0;
+  filter->b1 = b1 / a0;
+  filter->b2 = b2 / a0;
+  filter->a1 = a1 / a0;
+  filter->a2 = a2 / a0;
+}
+
+void DistortionEngine::ConfigureLowShelf(Biquad* filter, float frequency,
+                                         float q, float gainDb) {
+  float safeFrequency = Clamp(frequency, 10.0f, sampleRate_ * 0.45f);
+  float safeQ = q < 0.1f ? 0.1f : q;
+  float amplitude = powf(10.0f, gainDb / 40.0f);
+  float omega = 2.0f * kPi * safeFrequency / sampleRate_;
+  float alpha = sinf(omega) / (2.0f * safeQ);
+  float cosine = cosf(omega);
+  float amplitudeRoot = 2.0f * sqrtf(amplitude) * alpha;
+
+  float b0 = amplitude *
+             ((amplitude + 1.0f) - (amplitude - 1.0f) * cosine + amplitudeRoot);
+  float b1 = 2.0f * amplitude *
+             ((amplitude - 1.0f) - (amplitude + 1.0f) * cosine);
+  float b2 = amplitude *
+             ((amplitude + 1.0f) - (amplitude - 1.0f) * cosine - amplitudeRoot);
+  float a0 = (amplitude + 1.0f) + (amplitude - 1.0f) * cosine + amplitudeRoot;
+  float a1 = -2.0f * ((amplitude - 1.0f) + (amplitude + 1.0f) * cosine);
+  float a2 = (amplitude + 1.0f) + (amplitude - 1.0f) * cosine - amplitudeRoot;
+
+  filter->b0 = b0 / a0;
+  filter->b1 = b1 / a0;
+  filter->b2 = b2 / a0;
+  filter->a1 = a1 / a0;
+  filter->a2 = a2 / a0;
+}
+
+void DistortionEngine::ConfigureHighShelf(Biquad* filter, float frequency,
+                                          float q, float gainDb) {
+  float safeFrequency = Clamp(frequency, 10.0f, sampleRate_ * 0.45f);
+  float safeQ = q < 0.1f ? 0.1f : q;
+  float amplitude = powf(10.0f, gainDb / 40.0f);
+  float omega = 2.0f * kPi * safeFrequency / sampleRate_;
+  float alpha = sinf(omega) / (2.0f * safeQ);
+  float cosine = cosf(omega);
+  float amplitudeRoot = 2.0f * sqrtf(amplitude) * alpha;
+
+  float b0 = amplitude *
+             ((amplitude + 1.0f) + (amplitude - 1.0f) * cosine + amplitudeRoot);
+  float b1 = -2.0f * amplitude *
+             ((amplitude - 1.0f) + (amplitude + 1.0f) * cosine);
+  float b2 = amplitude *
+             ((amplitude + 1.0f) + (amplitude - 1.0f) * cosine - amplitudeRoot);
+  float a0 = (amplitude + 1.0f) - (amplitude - 1.0f) * cosine + amplitudeRoot;
+  float a1 = 2.0f * ((amplitude - 1.0f) - (amplitude + 1.0f) * cosine);
+  float a2 = (amplitude + 1.0f) - (amplitude - 1.0f) * cosine - amplitudeRoot;
+
+  filter->b0 = b0 / a0;
+  filter->b1 = b1 / a0;
+  filter->b2 = b2 / a0;
+  filter->a1 = a1 / a0;
+  filter->a2 = a2 / a0;
+}
+
+float DistortionEngine::ProcessBiquad(float sample, int channel,
+                                      Biquad* filter) {
+  float output = filter->b0 * sample + filter->z1[channel];
+  filter->z1[channel] =
+      filter->b1 * sample - filter->a1 * output + filter->z2[channel];
+  filter->z2[channel] = filter->b2 * sample - filter->a2 * output;
+  return output;
+}
+
+float DistortionEngine::MapShelfGain(float value, float cutDb, float boostDb) {
+  if (value < 0.5f) {
+    return -cutDb * (1.0f - value * 2.0f);
+  }
+
+  return boostDb * (value * 2.0f - 1.0f);
+}
+
+void DistortionEngine::ResetHalfband(Halfband* filter) {
+  for (int channel = 0; channel < kNumChannels; channel++) {
+    for (int path = 0; path < kHalfbandPaths; path++) {
+      for (int section = 0; section < kHalfbandSections; section++) {
+        filter->inputState[channel][path][section] = 0.0f;
+        filter->outputState[channel][path][section] = 0.0f;
+      }
+    }
+  }
+}
+
+float DistortionEngine::ProcessHalfbandAllpass(float sample, float coefficient,
+                                               float* inputState,
+                                               float* outputState) {
+  float output = *inputState + coefficient * (sample - *outputState);
+  *inputState = sample;
+  *outputState = output;
+  return output;
+}
+
+float DistortionEngine::ProcessHalfbandPath(float sample, int channel,
+                                            int path, Halfband* filter) {
+  float output = sample;
+  for (int section = 0; section < kHalfbandSections; section++) {
+    output = ProcessHalfbandAllpass(
+        output, kHalfbandCoefficients[path][section],
+        &filter->inputState[channel][path][section],
+        &filter->outputState[channel][path][section]);
+  }
+  return output;
+}
+
+void DistortionEngine::Upsample(float sample, int channel, Halfband* filter,
+                                float* outputs) {
+  outputs[0] = ProcessHalfbandPath(sample, channel, 0, filter);
+  outputs[1] = ProcessHalfbandPath(sample, channel, 1, filter);
+}
+
+float DistortionEngine::Downsample(const float* samples, int channel,
+                                   Halfband* filter) {
+  float even = ProcessHalfbandPath(samples[1], channel, 0, filter);
+  float odd = ProcessHalfbandPath(samples[0], channel, 1, filter);
+  return 0.5f * (even + odd);
+}
+
+float DistortionEngine::ApplyOnePoleHighpass(float sample, int channel,
+                                             float coefficient,
+                                             float* inputState,
+                                             float* outputState) {
+  float feedforward = 0.5f * (1.0f + coefficient);
+  float output = feedforward * (sample - inputState[channel]) +
+                 coefficient * outputState[channel];
+  inputState[channel] = sample;
+  outputState[channel] = output;
+  return output;
+}
+
+float DistortionEngine::UpdateNoiseGate(float sample, int channel) {
+  float magnitude = sample >= 0.0f ? sample : -sample;
+  float* envelope = &gateEnvelope_[channel];
+  float coefficient = magnitude > *envelope ? gateEnvelopeAttackCoefficient_
+                                            : gateEnvelopeReleaseCoefficient_;
+  *envelope += coefficient * (magnitude - *envelope);
+
+  if (*envelope >= kGateOpenThreshold) {
+    gateOpen_[channel] = true;
+    gateHoldCounter_[channel] = gateHoldSamples_;
+  } else if (*envelope < kGateCloseThreshold) {
+    if (gateHoldCounter_[channel] > 0) {
+      gateHoldCounter_[channel]--;
+    } else {
+      gateOpen_[channel] = false;
+    }
+  }
+
+  float target = gateOpen_[channel] ? 1.0f : 0.0f;
+  float gainCoefficient = target > gateGain_[channel] ? gateOpenCoefficient_
+                                                      : gateCloseCoefficient_;
+  gateGain_[channel] += gainCoefficient * (target - gateGain_[channel]);
+  return gateGain_[channel];
+}
+
+float DistortionEngine::ApplyDcBlock(float sample, int channel) {
+  return ApplyOnePoleHighpass(sample, channel, dcBlockerCoefficient_,
+                              dcInputState_, dcOutputState_);
+}
+
+float DistortionEngine::ApplyTightHighpass(float sample, int channel) {
+  return ApplyOnePoleHighpass(sample, channel, tightHighpassCoefficient_,
+                              tightInputState_, tightOutputState_);
+}
+
+float DistortionEngine::ApplyPreEmphasis(float sample, int channel) {
+  float boosted = ProcessBiquad(sample, channel, &preMidBoostFilter_);
+  return ProcessBiquad(boosted, channel, &preHighShelfFilter_);
+}
+
+float DistortionEngine::ApplyFirstClip(float sample) {
+  return tanhf(sample);
+}
+
+float DistortionEngine::ApplySecondClip(float sample) {
+  float driven = sample * kSecondClipGain;
+  if (driven > 1.0f) {
+    return 1.0f;
+  }
+  if (driven < -1.0f) {
+    return -1.0f;
+  }
+  return 1.5f * driven - 0.5f * driven * driven * driven;
+}
+
+float DistortionEngine::ApplyClipStages(float sample, int channel) {
+  float stage1[2];
+  float stage2[4];
+
+  Upsample(sample, channel, &upsampleStage1_, stage1);
+  Upsample(stage1[0], channel, &upsampleStage2_, &stage2[0]);
+  Upsample(stage1[1], channel, &upsampleStage2_, &stage2[2]);
+
+  for (int i = 0; i < 4; i++) {
+    stage2[i] = ApplySecondClip(ApplyFirstClip(stage2[i]));
+  }
+
+  stage1[0] = Downsample(&stage2[0], channel, &downsampleStage2_);
+  stage1[1] = Downsample(&stage2[2], channel, &downsampleStage2_);
+
+  return Downsample(stage1, channel, &downsampleStage1_);
+}
+
+float DistortionEngine::ApplyMidScoop(float sample, int channel) {
+  return ProcessBiquad(sample, channel, &midScoopFilter_);
+}
+
+float DistortionEngine::ApplyFizzLowpass(float sample, int channel) {
+  fizzState_[channel] +=
+      fizzLowpassCoefficient_ * (sample - fizzState_[channel]);
+  return fizzState_[channel];
+}
+
+float DistortionEngine::ApplyLowShelf(float sample, int channel) {
+  return ProcessBiquad(sample, channel, &lowShelfFilter_);
+}
+
+float DistortionEngine::ApplyHighShelf(float sample, int channel) {
+  return ProcessBiquad(sample, channel, &highShelfFilter_);
+}
+
+float DistortionEngine::OutputClamp(float sample) {
+  if (!(sample >= -FLT_MAX && sample <= FLT_MAX)) {
+    return 0.0f;
+  }
+
+  return Clamp(sample, -1.0f, 1.0f);
+}
+
+float DistortionEngine::ProcessSample(float sample, int channel) {
+  if (!(sample >= -FLT_MAX && sample <= FLT_MAX)) {
+    return 0.0f;
+  }
+
+  float dcBlocked = ApplyDcBlock(sample, channel);
+  float gateGain = UpdateNoiseGate(dcBlocked, channel);
+  float tightened = ApplyTightHighpass(dcBlocked, channel);
+  float emphasized = ApplyPreEmphasis(tightened, channel);
+  float driven = emphasized * distortionGain_;
+  float clipped = ApplyClipStages(driven, channel);
+  float scooped = ApplyMidScoop(clipped, channel);
+  float smoothed = ApplyFizzLowpass(scooped, channel);
+  float lowShaped = ApplyLowShelf(smoothed, channel);
+  float shaped = ApplyHighShelf(lowShaped, channel);
+  float output = shaped * levelGain_ * gateGain;
+
+  return OutputClamp(output);
+}

--- a/src/distortion/distortion_engine.h
+++ b/src/distortion/distortion_engine.h
@@ -1,0 +1,123 @@
+#ifndef DISTORTION_ENGINE_H
+#define DISTORTION_ENGINE_H
+
+#include <stddef.h>
+
+class DistortionEngine {
+ public:
+  void Init(float sampleRate);
+  void SetParameters(float distortion, float lowColor, float highColor,
+                     float level);
+  void ProcessBlock(const float* inputLeft, const float* inputRight,
+                    float* outputLeft, float* outputRight, size_t size);
+
+ private:
+  static const int kNumChannels = 2;
+  static const int kOversampleFactor = 4;
+  static const int kHalfbandPaths = 2;
+  static const int kHalfbandSections = 2;
+
+  struct Biquad {
+    float b0;
+    float b1;
+    float b2;
+    float a1;
+    float a2;
+    float z1[kNumChannels];
+    float z2[kNumChannels];
+  };
+
+  struct Halfband {
+    float inputState[kNumChannels][kHalfbandPaths][kHalfbandSections];
+    float outputState[kNumChannels][kHalfbandPaths][kHalfbandSections];
+  };
+
+  float Clamp(float value, float lower, float upper);
+  void UpdateSmoothingCoefficient(size_t blockSize);
+  void SmoothParameters();
+  void UpdateDerivedParameters();
+
+  void ResetBiquad(Biquad* filter);
+  void ConfigurePeaking(Biquad* filter, float frequency, float q,
+                        float gainDb);
+  void ConfigureLowShelf(Biquad* filter, float frequency, float q,
+                         float gainDb);
+  void ConfigureHighShelf(Biquad* filter, float frequency, float q,
+                          float gainDb);
+  float ProcessBiquad(float sample, int channel, Biquad* filter);
+  float MapShelfGain(float value, float cutDb, float boostDb);
+
+  void ResetHalfband(Halfband* filter);
+  float ProcessHalfbandAllpass(float sample, float coefficient,
+                               float* inputState, float* outputState);
+  float ProcessHalfbandPath(float sample, int channel, int path,
+                            Halfband* filter);
+  void Upsample(float sample, int channel, Halfband* filter, float* outputs);
+  float Downsample(const float* samples, int channel, Halfband* filter);
+
+  float ApplyOnePoleHighpass(float sample, int channel, float coefficient,
+                             float* inputState, float* outputState);
+  float UpdateNoiseGate(float sample, int channel);
+  float ApplyDcBlock(float sample, int channel);
+  float ApplyTightHighpass(float sample, int channel);
+  float ApplyPreEmphasis(float sample, int channel);
+  float ApplyFirstClip(float sample);
+  float ApplySecondClip(float sample);
+  float ApplyClipStages(float sample, int channel);
+  float ApplyMidScoop(float sample, int channel);
+  float ApplyFizzLowpass(float sample, int channel);
+  float ApplyLowShelf(float sample, int channel);
+  float ApplyHighShelf(float sample, int channel);
+  float OutputClamp(float sample);
+  float ProcessSample(float sample, int channel);
+
+  float sampleRate_;
+  size_t smoothingBlockSize_;
+  float smoothingCoefficient_;
+
+  float distortionTarget_;
+  float distortionCurrent_;
+  float lowTarget_;
+  float lowCurrent_;
+  float highTarget_;
+  float highCurrent_;
+  float levelTarget_;
+  float levelCurrent_;
+
+  float distortionGain_;
+  float distortionGainValue_;
+  float lowValue_;
+  float highValue_;
+  float levelGain_;
+
+  float dcBlockerCoefficient_;
+  float tightHighpassCoefficient_;
+  float fizzLowpassCoefficient_;
+  float gateEnvelopeAttackCoefficient_;
+  float gateEnvelopeReleaseCoefficient_;
+  float gateOpenCoefficient_;
+  float gateCloseCoefficient_;
+  int gateHoldSamples_;
+  float gateEnvelope_[kNumChannels];
+  float gateGain_[kNumChannels];
+  int gateHoldCounter_[kNumChannels];
+  bool gateOpen_[kNumChannels];
+  float dcInputState_[kNumChannels];
+  float dcOutputState_[kNumChannels];
+  float tightInputState_[kNumChannels];
+  float tightOutputState_[kNumChannels];
+  float fizzState_[kNumChannels];
+
+  Biquad preMidBoostFilter_;
+  Biquad preHighShelfFilter_;
+  Biquad midScoopFilter_;
+  Biquad lowShelfFilter_;
+  Biquad highShelfFilter_;
+
+  Halfband upsampleStage1_;
+  Halfband upsampleStage2_;
+  Halfband downsampleStage1_;
+  Halfband downsampleStage2_;
+};
+
+#endif


### PR DESCRIPTION
This adds a Boss MT-2 (Metal Zone) inspired stereo distortion firmware
in `src/distortion/`.

**Signal path:** DC blocker → tight highpass (75 Hz) → pre-emphasis
(mid boost 950 Hz, high shelf 2.2 kHz) → gain (3x–360x) → [4x
oversampling: tanh soft clip → cubic hard clip] → fixed mid scoop
(700 Hz, −8 dB) → fizz lowpass (7.5 kHz) → low/high shelf → level →
noise gate.

**Controls:** Pot 1 Distortion, Pot 2 Low, Pot 3 High, Pot 4 Level;
CV 1 modulates distortion, CV 2 modulates high (per the hardware
convention, inverted, scaled by 0.5).

**Notable details:**
- Clipping runs at 4x oversampling via polyphase allpass halfband
  filters (~70 dB stopband), so aliasing stays low at full gain
- A fixed noise gate (input sidechain, output attenuation, −54/−60 dBFS
  with hysteresis) mutes the amplified idle noise floor at high gain
- Fully stereo, no dynamic allocation, block-based parameter smoothing
- The DSP was verified numerically via a 1:1 Python port (halfband
  frequency response, alias suppression measurements, gate behavior)

Builds clean with the standard Makefile setup (~78 KB flash).