### PR TITLE
fix: Bootstrap initial release-please version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "packages": {
-    ".": {}
+    ".": {
+      "release-as": "0.1.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- release-please never opened a release PR because the only commit since setup used the `ci` type, which is not counted as user-facing by default
- Force the first release to 0.1.0 via `release-as` in release-please-config.json so a release PR gets proposed; the override should be removed after the first release is cut

## Test plan
- [ ] Confirm PR title lint runs on this PR (now that pr-title.yml is on main)
- [ ] Confirm release-please opens a release PR targeting 0.1.0 after this merges