### PR TITLE
fix: Attach built firmwares to releases created by release-please

### DIFF
--- a/.github/workflows/build-firmwares.yml
+++ b/.github/workflows/build-firmwares.yml
@@ -1,0 +1,57 @@
+name: Build Firmwares (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
+      attach-to-release:
+        required: false
+        type: boolean
+        default: false
+      tag-name:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+
+      - name: Set up ARM toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: "12.2.Rel1"
+
+      - name: Build libraries
+        run: ./build_libs.sh
+
+      - name: Build firmwares
+        run: python3 ./build_firmwares.py
+
+      - name: Collect binaries
+        run: |
+          mkdir -p artifacts
+          find src -type f -name '*.bin' -path '*/build/*' -exec cp {} artifacts/ \;
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmwares-${{ github.sha }}
+          path: artifacts/*.bin
+          if-no-files-found: error
+
+      - name: Attach firmwares to release
+        if: ${{ inputs.attach-to-release }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag-name }}
+          files: artifacts/*.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,47 +3,9 @@ name: Build Firmwares
 on:
   push:
   pull_request:
-  release:
-    types:
-      - created
-
-permissions:
-  contents: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Set up ARM toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: "12.2.Rel1"
-
-      - name: Build libraries
-        run: ./build_libs.sh
-
-      - name: Build firmwares
-        run: python3 ./build_firmwares.py
-
-      - name: Collect binaries
-        run: |
-          mkdir -p artifacts
-          find src -type f -name '*.bin' -path '*/build/*' -exec cp {} artifacts/ \;
-
-      - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: firmwares-${{ github.sha }}
-          path: artifacts/*.bin
-          if-no-files-found: error
-
-      - name: Attach firmwares to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: artifacts/*.bin
+    uses: ./.github/workflows/build-firmwares.yml
+    permissions:
+      contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,23 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-and-attach:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/build-firmwares.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+      attach-to-release: true
+      tag-name: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "packages": {
-    ".": {
-      "release-as": "0.1.0"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
## Summary
- Releases created by release-please-action use the default GITHUB_TOKEN, and GitHub does not let those trigger other workflows, so build.yml's `release: created` trigger never fired and v0.1.0 shipped with no assets
- Extract the firmware build into a reusable workflow (build-firmwares.yml) and have release-please.yml call it directly after cutting a release to attach the binaries in the same run
- Drop the one-time `release-as` bootstrap override now that the first release exists

## Test plan
- [ ] build.yml still passes on push/PR via the reusable workflow
- [ ] Merging triggers release-please to open a release PR; merging that PR should produce a release with .bin assets attached
