### PR TITLE
fix: Build Arduino-based firmwares in CI

### DIFF
--- a/.github/workflows/build-firmwares.yml
+++ b/.github/workflows/build-firmwares.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           release: "12.2.Rel1"
 
+      - name: Set up arduino-cli
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Set up DaisyDuino board support
+        run: |
+          arduino-cli config init --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          arduino-cli core update-index
+          arduino-cli core install STMicroelectronics:stm32
+          arduino-cli lib install DaisyDuino
+
       - name: Build libraries
         run: ./build_libs.sh
 

--- a/build_firmwares.py
+++ b/build_firmwares.py
@@ -9,8 +9,15 @@ import os
 import subprocess
 import pathlib
 
+# FQBN for the Daisy Seed, as configured by the DaisyDuino board support
+# package on top of the stm32duino STM32 core.
+ARDUINO_FQBN = (
+    "STMicroelectronics:stm32:GenH7:pnum=DAISY_SEED,upload_method=dfuMethod,"
+    "xserial=generic,usb=CDCgen,xusb=FS,opt=osstd,dbg=none,rtlib=nano"
+)
 
-def main():
+
+def build_makefiles():
     cwd = os.getcwd()
     for file in pathlib.Path("src").rglob("Makefile"):
         folder = file.parents[0]
@@ -22,6 +29,27 @@ def main():
             os.chdir(cwd)
             sys.exit(1)
         os.chdir(cwd)
+
+
+def build_arduino_sketches():
+    for folder in sorted(pathlib.Path("src").iterdir()):
+        sketch = folder / "{}.ino".format(folder.name)
+        if (folder / "Makefile").exists() or not sketch.exists():
+            continue
+        os.system("echo Building: {}".format(folder))
+        exit_code = subprocess.call(
+            "arduino-cli compile --fqbn {} --output-dir {} {}".format(
+                ARDUINO_FQBN, folder / "build", folder
+            ),
+            shell=True,
+        )
+        if exit_code != 0:
+            sys.exit(1)
+
+
+def main():
+    build_makefiles()
+    build_arduino_sketches()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- compressor, delay, reverb, and shimmer-reverb only have an .ino sketch with no Makefile, so build_firmwares.py silently skipped them and CI never produced binaries for them
- build_firmwares.py now also compiles any src/<name>/<name>.ino sketch without a Makefile via arduino-cli, using the FQBN DaisyDuino documents for the Daisy Seed
- CI installs arduino-cli, the STMicroelectronics:stm32 core, and the DaisyDuino library those sketches depend on before building

## Test plan
- [ ] CI build produces .bin artifacts for all 10 firmwares (6 Makefile-based + 4 Arduino-based)
